### PR TITLE
Fix timestamp accuracy problem

### DIFF
--- a/app/src/main/java/com/timestamper/model/Timestamp.java
+++ b/app/src/main/java/com/timestamper/model/Timestamp.java
@@ -1,14 +1,9 @@
 package com.timestamper.model;
 
 public class Timestamp {
-    int unix_timestamp;
+    Long unix_timestamp;
 
     public Timestamp() {
-        unix_timestamp = (int)System.currentTimeMillis();
-    }
-
-    public static void main(String[] args) {
-        Timestamp myObj = new Timestamp();
-        System.out.println(myObj.unix_timestamp);
+        unix_timestamp = System.currentTimeMillis()/1000;
     }
 }


### PR DESCRIPTION
Found the problem with the inaccurate timestamp. For some reason when I was casting `System.currentTimeMillis()` as type `int` it was converting the value. Not sure why but it was. I changed it to it's native `Long` type, and divided by 1000 to get the number of seconds which is what the backend is expecting.

I also got rid of an unnecessary method in the `Timestamp` object.

Once you've reviewed and approved, you can merge it into develop. Then, pull down the changes to your local develop branch, merge it into master and push up master, and the app will build and release in AppCenter in a few minutes.

In sum, once you merge this Pull Request into develop you need to run the following locally:

`git checkout develop` (if not already on develop)
`git pull origin develop`
`git checkout master`
`git merge develop` (This merges `develop` into the current branch you are in, which should be `master`)
`git push origin master`